### PR TITLE
Make wintergear default shop for testing

### DIFF
--- a/wintergear_demo_content/management/commands/wintergear_import_demo.py
+++ b/wintergear_demo_content/management/commands/wintergear_import_demo.py
@@ -30,7 +30,7 @@ class Command(BaseCommand):
         migrator.handle(database="default", verbosity=1, noinput=True, app_label=None, migration_name=None)
 
         if not Shop.objects.exists():
-            Shop.objects.create(name="Wintergear", identifier="wintergear", status=ShopStatus.ENABLED)
+            Shop.objects.create(name="Wintergear", identifier="default", status=ShopStatus.ENABLED)
             try:
                 tax_class = TaxClass.objects.create(identifier="default", tax_rate=0)
             except:


### PR DESCRIPTION
Shoop testing module which is used to create mock data, get or creates
shop with identifier "default". Avoid the situation that the testing
module creates new shop since it causes multishop situation that won't
work since ShoopFrontMiddleware uses always first shop in database.

Refs SHOOP-2157 / SHOOP-2169
